### PR TITLE
Fix empty arguments handling in OpenAI tool calls

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 replace github.com/yukinagae/genkit-go-plugins => ../
 
 require (
-	github.com/firebase/genkit/go v0.1.1
+	github.com/firebase/genkit/go v0.2.1
 	github.com/yukinagae/genkit-go-plugins v0.0.0-00010101000000-000000000000
 )
 
@@ -17,8 +17,8 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/invopop/jsonschema v0.12.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
-	github.com/openai/openai-go v0.1.0-alpha.13 // indirect
-	github.com/tidwall/gjson v1.17.3 // indirect
+	github.com/openai/openai-go v0.1.0-alpha.61 // indirect
+	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/tidwall/sjson v1.2.5 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -7,6 +7,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/firebase/genkit/go v0.1.1 h1:Cg1cjRvfJeZdCgs5JXYOV2JhXw64SZroJv/mOnTlVWw=
 github.com/firebase/genkit/go v0.1.1/go.mod h1:XDbSDe348obNc/dqObxx7znYhANXoOQO9KdFamt1eS4=
+github.com/firebase/genkit/go v0.2.1/go.mod h1:V9hjXN8+1vE8ac7GtKcpn4lrXLPCeatA6YPhv0jVnUE=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=
 github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -23,6 +24,7 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/openai/openai-go v0.1.0-alpha.13 h1:8Yf9zWYX2MeK3WU7Yf1vlUWOjIB0baY+8gTspfZyhw8=
 github.com/openai/openai-go v0.1.0-alpha.13/go.mod h1:3SdE6BffOX9HPEQv8IL/fi3LYZ5TUpRYaqGQZbyk11A=
+github.com/openai/openai-go v0.1.0-alpha.61/go.mod h1:3SdE6BffOX9HPEQv8IL/fi3LYZ5TUpRYaqGQZbyk11A=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -32,6 +34,7 @@ github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.17.3 h1:bwWLZU7icoKRG+C+0PNwIKC6FCJO/Q3p2pZvuP0jN94=
 github.com/tidwall/gjson v1.17.3/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=

--- a/plugins/openai/convert.go
+++ b/plugins/openai/convert.go
@@ -167,6 +167,9 @@ func convertToolCall(part *ai.Part) goopenai.ChatCompletionMessageToolCallParam 
 
 	if len(part.ToolRequest.Input) > 0 {
 		param.Function.Value.Arguments = goopenai.F(mapToJSONString(part.ToolRequest.Input))
+	} else {
+		// NOTE: OpenAI API requires the Arguments field to be set even if it's empty.
+		param.Function.Value.Arguments = goopenai.F("{}")
 	}
 
 	return param

--- a/plugins/openai/convert_test.go
+++ b/plugins/openai/convert_test.go
@@ -304,7 +304,8 @@ func TestConvertToolCall(t *testing.T) {
 				ID:   goopenai.F("tellAFunnyJoke"),
 				Type: goopenai.F(goopenai.ChatCompletionMessageToolCallTypeFunction),
 				Function: goopenai.F(goopenai.ChatCompletionMessageToolCallFunctionParam{
-					Name: goopenai.F("tellAFunnyJoke"),
+					Name:      goopenai.F("tellAFunnyJoke"),
+					Arguments: goopenai.F("{}"),
 				}),
 			},
 		},
@@ -320,7 +321,8 @@ func TestConvertToolCall(t *testing.T) {
 				ID:   goopenai.F("tellAFunnyJoke"),
 				Type: goopenai.F(goopenai.ChatCompletionMessageToolCallTypeFunction),
 				Function: goopenai.F(goopenai.ChatCompletionMessageToolCallFunctionParam{
-					Name: goopenai.F("tellAFunnyJoke"),
+					Name:      goopenai.F("tellAFunnyJoke"),
+					Arguments: goopenai.F("{}"),
 				}),
 			},
 		},


### PR DESCRIPTION
I discovered a bug where OpenAI generates text when `genkit` is called for a toolRequest with empty arguments. Instead, it should be called with `{}` as its argument.